### PR TITLE
fix(scripts): remove broken yarn validate

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
         "lint": "eslint src/{data,domain,scripts,types,utils}/**/*.ts --ext .ts",
         "start": "ts-node ./src/scripts/index.ts",
         "start-comparator": "vite --strictPort",
-        "validate": "ts-node ./src/validateSchema.ts",
         "prettify": "prettier \"./**/*.{js,jsx,json,css,ts,tsx}\" --write",
         "metadata-build": "ts-node ./src/scripts/index.ts metadata build"
     },


### PR DESCRIPTION
## Summary

The `validate` entry in `package.json` points at `src/validateSchema.ts`, which was deleted in commit `0e2a5a0` ("rm unused"). Running `yarn validate` fails with a confusing ts-node `MODULE_NOT_FOUND` stacktrace pointing at an `imaginaryUncacheableRequireResolveScript` synthetic path — not obvious that the underlying issue is just a stale package.json entry.

This PR removes the orphaned script.

## Why not re-implement instead

Adding a real `metadata validate` cmd-ts subcommand (calling `validateFiles` from `src/helpers/files.ts` and codec-based payload checks) would be a feature addition. Keeping this PR scoped to the bug fix; the feature can come in a separate PR if `yarn validate` should be restored as a real command.

## Cross-ref

The `dhis2-metadata-as-code` Claude Code skill at `~/.claude/skills/dhis2-metadata-as-code/SKILL.md` lists `yarn validate` as one of the key entrypoints. After this lands, that mention should be updated to either point at `yarn metadata-build` (which validates as part of build) or marked as deferred until a real validate command exists. I'll handle that follow-up in the skill.

## Test plan

- [x] `yarn validate` after the change → fails cleanly with `error Command "validate" not found.`
- [x] All other yarn scripts still listed (27 → 26)
- [ ] CI passes

## Related Tasks

_(no ClickUp link — couldn't create the ticket, MCP ClickUp connector is disconnected. Please add the link when picking this up.)_