### PR TITLE
fix(scripts): resolve metadata-build paths from cwd, not __dirname

### DIFF
--- a/src/scripts/commands/build.ts
+++ b/src/scripts/commands/build.ts
@@ -16,11 +16,11 @@ export const build = command({
 
             console.debug("Building metadata...");
         
-        const capturePath = path.join(__dirname, "../capture");
-        const visualizationPath = path.join(__dirname, "../visualizations");
-        const permissionPath = path.join(__dirname, "../permissions");
+        const capturePath = path.resolve("capture");
+        const visualizationPath = path.resolve("visualizations");
+        const permissionPath = path.resolve("permissions");
 
-        const outputPath = path.join(__dirname, "../output");
+        const outputPath = path.resolve("output");
 
         const captureRepository = new MetadataJSONRepository(capturePath, outputPath);
         const visualizationRepository = new MetadataJSONRepository(


### PR DESCRIPTION
## Summary

`yarn metadata-build` was failing with `ENOENT: no such file or directory, scandir '<repo>/src/scripts/capture'` when run from the repo root. The bug: `src/scripts/commands/build.ts` resolved its four input/output dirs via `path.join(__dirname, "../<dir>")`, which lands at `src/scripts/<dir>` instead of the repo root (where the README documents them).

This PR makes the paths cwd-relative via `path.resolve("<dir>")` — natural for a CLI invoked through yarn from the repo root.

Also adds `capture/.gitkeep` so the skeleton ships the canonical layout symmetrically. `permissions/` and `visualizations/` already exist as empty dirs at repo root; `capture/` was missing (empty dirs don't survive `git add`).

## Diff

```diff
-        const capturePath = path.join(__dirname, "../capture");
-        const visualizationPath = path.join(__dirname, "../visualizations");
-        const permissionPath = path.join(__dirname, "../permissions");
-        const outputPath = path.join(__dirname, "../output");
+        const capturePath = path.resolve("capture");
+        const visualizationPath = path.resolve("visualizations");
+        const permissionPath = path.resolve("permissions");
+        const outputPath = path.resolve("output");
```

## Test plan

Verified locally (skeleton root, current branch):

```
$ yarn metadata-build
$ ts-node ./src/scripts/index.ts metadata build
Building metadata...

----------------------------------------
  Validation Message: No JSON files found in capture folder (/home/.../dhis2-metadata-skeleton/capture)
  Validation Message: No JSON files found in visualizations folder (/home/.../dhis2-metadata-skeleton/visualizations)
  Validation Message: No JSON files found in permissions folder (/home/.../dhis2-metadata-skeleton/permissions)
----------------------------------------

Error building metadata: Error: Validation failed. Please check the errors above.
```

That's the **success case** for path resolution — paths now resolve correctly to the repo-root dirs; the validation step then complains about empty dirs (expected — there's no real metadata in the skeleton itself). Before this PR, the same command crashed with `ENOENT` on `<repo>/src/scripts/capture`.

A downstream metadata repo (e.g. `metadata-LIVVAE` with a populated `capture/`, `visualizations/`, `permissions/`) will be able to actually run a successful build once this lands and gets pulled via the `template` remote.

- [x] `yarn metadata-build` no longer crashes on `ENOENT`
- [x] All four paths verified resolved to the repo root
- [x] `capture/`, `visualizations/`, `permissions/` are symmetrically present (`.gitkeep` placeholders)
- [ ] CI passes

## Out of scope (separate skeleton hygiene)

- 5 `.DS_Store` files are committed in the repo (`.DS_Store`, `output/.DS_Store`, `permissions/.DS_Store`, `src/.DS_Store`, `visualizations/.DS_Store`). Worth a follow-up PR to `git rm` them and add `.DS_Store` to `.gitignore`. Not touched here.
- `cmd-ts` is pinned at `^0.13.0` in `dependencies` and `^0.12.1` in `devDependencies`. yarn warns on every script run. Pre-existing; resolve in a separate dependency-cleanup PR.

## Related Tasks

_(no ClickUp link — couldn't create the ticket, MCP ClickUp connector is disconnected. Please add the link when picking this up.)_
