### PR TITLE
fix(domain): concatUnique crashes when an input is undefined

### DIFF
--- a/src/domain/usecases/helpers/__tests__/concatUnique.spec.ts
+++ b/src/domain/usecases/helpers/__tests__/concatUnique.spec.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { concatUnique } from "../concatUnique";
+
+describe("concatUnique", () => {
+    it("returns the union of two arrays, deduplicated by id", () => {
+        const a = [{ id: "a1" }, { id: "a2" }];
+        const b = [{ id: "a2" }, { id: "b1" }];
+
+        expect(concatUnique(a, b)).toEqual([{ id: "a1" }, { id: "a2" }, { id: "b1" }]);
+    });
+
+    it("preserves the first occurrence when the same id appears in both arrays", () => {
+        const a = [{ id: "x", tag: "from-a" }] as const;
+        const b = [{ id: "x", tag: "from-b" }] as const;
+
+        expect(concatUnique(a, b)).toEqual([{ id: "x", tag: "from-a" }]);
+    });
+
+    it("treats an undefined first argument as an empty array", () => {
+        // Regression: callers in the *CombineAndRemoveDuplicates use cases pass
+        // `data.<key>` for a `<key>` that may be absent on the input file
+        // (e.g. a tracker-only capture file has no `dataSets` key, so
+        // `data.dataSets` is `undefined`). Before the fix, this crashed in
+        // Collection.uniqBy with `Cannot read properties of undefined (reading 'id')`.
+        expect(concatUnique<{ id: string }>(undefined, [{ id: "b1" }])).toEqual([{ id: "b1" }]);
+    });
+
+    it("treats an undefined second argument as an empty array", () => {
+        expect(concatUnique<{ id: string }>([{ id: "a1" }], undefined)).toEqual([{ id: "a1" }]);
+    });
+
+    it("returns an empty array when both arguments are undefined", () => {
+        expect(concatUnique<{ id: string }>(undefined, undefined)).toEqual([]);
+    });
+
+    it("returns an empty array when both arguments are empty", () => {
+        expect(concatUnique<{ id: string }>([], [])).toEqual([]);
+    });
+});

--- a/src/domain/usecases/helpers/concatUnique.ts
+++ b/src/domain/usecases/helpers/concatUnique.ts
@@ -1,9 +1,16 @@
 import { Ref } from "../../entities/Ref";
 import _ from "../../entities/generic/Collection";
 
-export function concatUnique<T extends Ref>(objs1: T[], objs2: T[]): T[] {
-    return _(objs1)
-        .concat(_(objs2))
+// Accepts `undefined` because the *CombineAndRemoveDuplicates use cases pass
+// `data.<key>` straight from input files, and a given JSON file may legitimately
+// omit a top-level key (e.g. a tracker-only capture file has no `dataSets`).
+// Before this defensive default, an absent key crashed inside Collection.uniqBy.
+export function concatUnique<T extends Ref>(
+    objs1: T[] | undefined,
+    objs2: T[] | undefined
+): T[] {
+    return _(objs1 ?? [])
+        .concat(_(objs2 ?? []))
         .uniqBy(obj => obj.id)
         .value();
 }


### PR DESCRIPTION
## Summary

`concatUnique<T extends Ref>(objs1: T[], objs2: T[])` is the per-resource-type merge helper used by all three of `DataSetProgramCombineAndRemoveDuplicatesUseCase`, `PermissionCombineAndRemoveDuplicatesUseCase`, and `VisualizationCombineAndRemoveDuplicatesUseCase`. They call `concatUnique(acc.<key>, data.<key>)` for every key in their respective `Processed*` shapes (15 keys for DataSetProgram, 5 for Visualization, 2 for Permission).

The bug: a given input JSON file can legitimately omit any of those keys. A tracker-only capture file has no `dataSets`, a permissions file has no `dashboards`, etc. Then `data.<key>` is `undefined`, and the helper crashed inside `Collection.uniqBy`:

```
TypeError: Cannot read properties of undefined (reading 'id')
  at concatUnique.ts:7:28
  at Collection.uniqBy
  at DataSetProgramCombineAndRemoveDuplicatesUseCase.combineAndRemoveDuplicatesById
```

## Fix

Accept `T[] | undefined` on both arguments and default each to `[]` before the union+dedupe. Three lines of code; one comment explaining why.

```diff
-export function concatUnique<T extends Ref>(objs1: T[], objs2: T[]): T[] {
-    return _(objs1)
-        .concat(_(objs2))
+export function concatUnique<T extends Ref>(
+    objs1: T[] | undefined,
+    objs2: T[] | undefined
+): T[] {
+    return _(objs1 ?? [])
+        .concat(_(objs2 ?? []))
        .uniqBy(obj => obj.id)
        .value();
}
```

The signature change is non-breaking. Every existing call site passes either an array or `undefined`, never anything else; the new lenient signature accepts both.

## Test

`src/domain/usecases/helpers/__tests__/concatUnique.spec.ts` — 6 cases:

- ✅ returns the union, deduplicated by id (happy path)
- ✅ first-occurrence-wins on duplicate ids
- ✅ undefined first arg → treats as empty (regression)
- ✅ undefined second arg → treats as empty (regression)
- ✅ both undefined → empty array (regression)
- ✅ both empty → empty array

Before this PR all 3 regression cases fail; after they pass. Other 3 happy-path cases pass on both versions.

## Reproduction

Against the [metadata-LIVVAE](https://github.com/EyeSeeTea/metadata-LIVVAE) repo's `capture/` directory (tracker-only programs, no `dataSets`):

```
$ yarn metadata-build
Error processing datasets: TypeError: Cannot read properties of undefined (reading 'id')
  at concatUnique.ts:7:28
```

After this fix, `concatUnique` no longer aborts the combine pass on absent keys. (Path resolution from cwd still requires PR #8 to actually run end-to-end against a downstream repo.)

## Pre-existing test failure note

`yarn check-code` reports 2 failures in `src/webapp/pages/app/__tests__/App.spec.tsx` ("App > navigates to page 1" + 1 obsolete snapshot). I confirmed they're **pre-existing on `feature/metadata-comparator-app`** — they fail on the base branch with the same trace, before any of my changes. Out of scope for this PR; worth tracking separately.

## Related Tasks

_(no ClickUp link — couldn't create the ticket, MCP ClickUp connector is disconnected. Please add the link when picking this up.)_